### PR TITLE
Fix broken bis.doc.gov link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Olm (libolm) is an independent Apache-licensed implementation of the Double Ratc
 
 The Olm repository now lives at https://gitlab.matrix.org/matrix-org/olm.
 
-We don't host Olm on Github as that would constitute re-exporting its cryptography to/from the US, which technically requires us to file additional paperwork with the US government: see https://www.bis.doc.gov/index.php/policy-guidance/encryption/encryption-faqs#6 for details.  Given Olm is currently developed in the UK & France, and https://matrix.org/git is hosted in UK / Holland / Germany, we store the code on this side of the Atlantic :)
+We don't host Olm on Github as that would constitute re-exporting its cryptography to/from the US, which technically requires us to file additional paperwork with the US government: see https://www.bis.doc.gov/index.php/policy-guidance/encryption/6-faqs for details.  Given Olm is currently developed in the UK & France, and https://matrix.org/git is hosted in UK / Holland / Germany, we store the code on this side of the Atlantic :)
 
 ## Bug reporting
 


### PR DESCRIPTION
The link in the readme as-is 404's; I did some searching and I think this is the right page.

Signed-off-by: Phil Denhoff <phil@denhoff.ca>